### PR TITLE
perl runtime files are required for remote execution

### DIFF
--- a/perl_genrule.bzl
+++ b/perl_genrule.bzl
@@ -96,7 +96,7 @@ def _perl_genrule_impl(ctx):
     perl_generate_file = ctx.file._perl_generate_file
     if ctx.attr.is_unix:
         ctx.actions.run(
-            inputs = srcs_as_files + additional_srcs + [ctx.attr._perl_toolchain[platform_common.ToolchainInfo].perl_runtime.interpreter],
+            inputs = srcs_as_files + additional_srcs + [ctx.attr._perl_toolchain[platform_common.ToolchainInfo].perl_runtime.interpreter] + ctx.attr._perl_toolchain[platform_common.ToolchainInfo].perl_runtime.runtime.to_list(),
             outputs = outs_as_files,
             executable = perl_generate_file,
             arguments = [commands_joined],

--- a/perl_genrule.bzl
+++ b/perl_genrule.bzl
@@ -96,7 +96,7 @@ def _perl_genrule_impl(ctx):
     perl_generate_file = ctx.file._perl_generate_file
     if ctx.attr.is_unix:
         ctx.actions.run(
-            inputs = srcs_as_files + additional_srcs + [ctx.attr._perl_toolchain[platform_common.ToolchainInfo].perl_runtime.interpreter] + ctx.attr._perl_toolchain[platform_common.ToolchainInfo].perl_runtime.runtime.to_list(),
+            inputs = depset(direct = srcs_as_files + additional_srcs + [ctx.attr._perl_toolchain[platform_common.ToolchainInfo].perl_runtime.interpreter], transitive = [ctx.attr._perl_toolchain[platform_common.ToolchainInfo].perl_runtime.runtime]),
             outputs = outs_as_files,
             executable = perl_generate_file,
             arguments = [commands_joined],


### PR DESCRIPTION
Fixes https://github.com/raccoons-build/bazel-openssl-cc/issues/28

Provide the runtime files to the action so that a remote executor is aware of those dependencies.

