### PR TITLE
Re-add gen_dir

### DIFF
--- a/BUILD.openssl.bazel
+++ b/BUILD.openssl.bazel
@@ -695,3 +695,9 @@ collate_into_directory(
     ],
     visibility = ["//visibility:public"],
 )
+
+alias(
+    name = "gen_dir",
+    actual = ":install",
+    visibility = ["//visibility:public"],
+)


### PR DESCRIPTION
This target used to be called gen_dir, and a bunch of folks have copy+pasted snippets into crate_universes using it.

closes https://github.com/raccoons-build/bazel-openssl-cc/issues/66