### PR TITLE
windows: Stop propagating _WINSOCKAPI_ and WIN32_LEAN_AND_MEAN to consumers

### DIFF
--- a/BUILD.openssl.bazel
+++ b/BUILD.openssl.bazel
@@ -439,14 +439,24 @@ COMMON_OPENSSL_COPTS = [
 
 COMMON_DEFINES = select({
     "//configs:windows_msvc": [
-        "_WINSOCKAPI_",
         "OPENSSL_SYS_WINCE",
+    ],
+    "//configs:windows_non_msvc": [
+        "SIO_UDP_NETRESET=0x9800001C",
+    ],
+    "//conditions:default": [],
+})
+
+# _WINSOCKAPI_ and WIN32_LEAN_AND_MEAN are openssl-internal and must not
+# propagate to consumers via CcInfo.
+COMMON_LOCAL_DEFINES = select({
+    "//configs:windows_msvc": [
+        "_WINSOCKAPI_",
         "WIN32_LEAN_AND_MEAN",
     ],
     "//configs:windows_non_msvc": [
         "_WINSOCKAPI_",
         "WIN32_LEAN_AND_MEAN",
-        "SIO_UDP_NETRESET=0x9800001C",
     ],
     "//conditions:default": [],
 })
@@ -544,6 +554,7 @@ cc_library(
         "//conditions:default": NO_ASM_DEFINES,
     }),
     defines = COMMON_DEFINES,
+    local_defines = COMMON_LOCAL_DEFINES,
     includes = LIBCRYPTO_INCLUDES + select({
         "@platforms//os:windows": LIBCRYPTO_WINDOWS_INCLUDES,
         "//conditions:default": [],
@@ -610,6 +621,7 @@ cc_library(
         "//conditions:default": NO_ASM_DEFINES,
     }),
     defines = COMMON_DEFINES,
+    local_defines = COMMON_LOCAL_DEFINES,
     includes = ["include"],
     linkopts = select({
         "@platforms//os:windows": [],
@@ -680,6 +692,7 @@ cc_binary(
         "//conditions:default": [],
     }),
     defines = COMMON_DEFINES,
+    local_defines = COMMON_LOCAL_DEFINES,
     includes = [
         "apps",
         "apps/include",

--- a/BUILD.openssl.bazel
+++ b/BUILD.openssl.bazel
@@ -570,7 +570,6 @@ cc_library(
         "//conditions:default": NO_ASM_DEFINES,
     }),
     defines = COMMON_DEFINES,
-    local_defines = COMMON_LOCAL_DEFINES,
     includes = LIBCRYPTO_INCLUDES + select({
         "@platforms//os:windows": LIBCRYPTO_WINDOWS_INCLUDES,
         "//conditions:default": [],
@@ -592,6 +591,7 @@ cc_library(
             "-pthread",
         ],
     }),
+    local_defines = COMMON_LOCAL_DEFINES,
     textual_hdrs = CRYPTO_TEXTUAL_HDRS,
     visibility = ["//visibility:public"],
 )
@@ -642,12 +642,12 @@ cc_library(
         "//conditions:default": NO_ASM_DEFINES,
     }),
     defines = COMMON_DEFINES,
-    local_defines = COMMON_LOCAL_DEFINES,
     includes = ["include"],
     linkopts = select({
         "@platforms//os:windows": [],
         "//conditions:default": ["-lc"],
     }),
+    local_defines = COMMON_LOCAL_DEFINES,
     visibility = ["//visibility:public"],
     deps = [":crypto"],
 )
@@ -713,11 +713,11 @@ cc_binary(
         "//conditions:default": [],
     }),
     defines = COMMON_DEFINES,
-    local_defines = COMMON_LOCAL_DEFINES,
     includes = [
         "apps",
         "apps/include",
     ],
+    local_defines = COMMON_LOCAL_DEFINES,
     visibility = ["//visibility:public"],
     deps = [":ssl"],
 )


### PR DESCRIPTION
Move `_WINSOCKAPI_` and `WIN32_LEAN_AND_MEAN` to `local_defines` at `:crypto`, `:ssl`, and `:openssl` instead of `defines`. 

`_WINSOCKAPI_` leaking breaks any consumer using #ifndef _WINSOCKAPI_  #include <winsock2.h> guard pattern (curl, grpc, etc.) -- see example below. 

`WIN32_LEAN_AND_MEAN` is a per-consumer choice that a library should not impose on its dependents.

--- 
## Issue Reproduction

**MODULE.bazel**

```bzl
module(name = "repro", version = "0.0.0")

bazel_dep(name = "openssl", version = "3.5.5.bcr.4")
bazel_dep(name = "rules_cc", version = "0.2.17")
bazel_dep(name = "curl", version = "8.12.0.bcr.1")
```

**BUILD.bazel**
```bzl
load("@rules_cc//cc:cc_test.bzl", "cc_test")

cc_test(
    name = "repro",
    srcs = ["repro.cpp"],
    deps = ["@openssl//:ssl", "@curl"],
)
```

**repro.cpp**
```cpp
#include <openssl/ssl.h>

// This is the standard pattern used by curl, grpc, and others:
// skip winsock2 include if _WINSOCKAPI_ is already set.
// see https://github.com/curl/curl/blob/master/include/curl/curl.h#L78
#ifndef _WINSOCKAPI_
#include <winsock2.h>
#endif

SOCKET s;

int main() { return 0; }
```

or
```c
#include <curl/curl.h>
#include <openssl/ssl.h>
int main() { return 0; }
```

### Result
```
bazelisk build //:repro
# -> repro.cpp(9): error C4430: missing type specifier - int assumed
# -> repro.cpp(9): error C2146: syntax error: missing ';' before identifier 's'
```
