### PR TITLE
Propagate Windows system-lib linkopts from //:crypto

### DIFF
--- a/BUILD.configs.bazel
+++ b/BUILD.configs.bazel
@@ -173,6 +173,19 @@ selects.config_setting_group(
     visibility = ["//visibility:public"],
 )
 
+# clang on Windows is the LLVM mingw/gnullvm driver, which links GNU-style
+# ("-l") -- unlike clang-cl, which uses the MSVC linker.
+config_setting(
+    name = "windows_clang",
+    constraint_values = [
+        "@platforms//os:windows",
+    ],
+    flag_values = {
+        "@rules_cc//cc/compiler": "clang",
+    },
+    visibility = ["//visibility:public"],
+)
+
 config_setting(
     name = "linux_riscv64",
     constraint_values = [

--- a/BUILD.openssl.bazel
+++ b/BUILD.openssl.bazel
@@ -468,6 +468,22 @@ LIBCRYPTO_WINDOWS_INCLUDES = [
     "crypto/bn",
 ]
 
+# crypt32 is pulled in by the CAPI engine (engines/e_capi.c); ws2_32/advapi32/
+# user32 back sockets and registry/user APIs.
+_WINDOWS_SYSTEM_LIBS_MSVC = [
+    "-defaultlib:ws2_32.lib",
+    "-defaultlib:advapi32.lib",
+    "-defaultlib:user32.lib",
+    "-defaultlib:crypt32.lib",
+]
+
+_WINDOWS_SYSTEM_LIBS_GNU = [
+    "-lws2_32",
+    "-ladvapi32",
+    "-luser32",
+    "-lcrypt32",
+]
+
 # --- libcrypto ---
 
 COMMON_LIBCRYPTO_HDRS = glob(
@@ -554,6 +570,11 @@ cc_library(
             "-ldl",
             "-pthread",
         ],
+        "//configs:windows_msvc": _WINDOWS_SYSTEM_LIBS_MSVC,
+        "//configs:windows_clang_cl": _WINDOWS_SYSTEM_LIBS_MSVC,
+        "//configs:windows_mingw": _WINDOWS_SYSTEM_LIBS_GNU,
+        "//configs:windows_clang": _WINDOWS_SYSTEM_LIBS_GNU,
+        # Prevents unmatched Windows compilers from falling to the Unix default.
         "@platforms//os:windows": [],
         "//conditions:default": [
             "-lc",
@@ -684,21 +705,6 @@ cc_binary(
         "apps",
         "apps/include",
     ],
-    linkopts = select({
-        "//configs:windows_msvc": [
-            "-defaultlib:ws2_32.lib",
-            "-defaultlib:advapi32.lib",
-            "-defaultlib:user32.lib",
-            "-defaultlib:crypt32.lib",
-        ],
-        "//configs:windows_non_msvc": [
-            "-lws2_32",
-            "-ladvapi32",
-            "-luser32",
-            "-lcrypt32",
-        ],
-        "//conditions:default": [],
-    }),
     visibility = ["//visibility:public"],
     deps = [":ssl"],
 )


### PR DESCRIPTION
## Problem

The Win32 system libraries (`crypt32`/`ws2_32`/`advapi32`/`user32`) are declared only on the `openssl` CLI `cc_binary`. `cc_binary` linkopts don't propagate, so a downstream consumer that links `@openssl//:crypto`/`:ssl` into its own executable fails at link time with undefined `Cert*`/socket symbols. The libraries' own Windows `linkopts` are empty. (Surfaced building a `cc_library`  against openssl using clang-mingw..)

## Fix

Builds on #68. Declares the libs on **`//:crypto`** so they propagate transitively to every consumer (and to the CLI, which now inherits them), spelled per the target **linker** ABI in a single `select`:

- `msvc-cl` and `clang-cl` → MSVC linker → `-defaultlib:`
- `mingw-gcc` and `clang` → GNU linker → `-l`

Adds a `windows_clang` `config_setting`. #68 added `msvc-cl`/`clang-cl`/`mingw-gcc` but not plain `clang`, which is the LLVM windows-gnu (mingw/gnullvm) driver. Each compiler `config_setting` refines `@platforms//os:windows`, so a catchall `@platforms//os:windows` arm keeps any *other* Windows compiler off the Unix `-lc -pthread` default. Note this linker split is intentionally different from #68's `windows_non_msvc` grouping, which is right for the *assembler* but wrong for *linking* (clang-cl uses the MSVC linker).

The CLI's own Windows `linkopts` (added in #68) are removed, since it now inherits the correct set for all ABIs from `//:crypto`.

## Testing

buildifier clean. Exercised end-to-end via a proof of concept overlay from the BCR (undefined `Cert*` → links). Note BCR's Windows CI runners are MSVC-only, so the MSVC arm is CI-covered; the mingw/`-l` arm is validated by hand.