### PR TITLE
Bump rules_perl to 1.1.2

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,5 +1,5 @@
 module(name = "openssl_generator")
 
 bazel_dep(name = "buildifier_prebuilt", version = "8.5.1")
-bazel_dep(name = "rules_perl", version = "1.1.0")
+bazel_dep(name = "rules_perl", version = "1.1.2")
 bazel_dep(name = "rules_python", version = "1.9.0")

--- a/generate_constants.py
+++ b/generate_constants.py
@@ -1359,7 +1359,7 @@ def write_bcr_files(out: Path, bcr_dir: str, tag: str, source_archive: str) -> N
         bazel_dep(name = "bazel_skylib", version = "1.7.1")
         bazel_dep(name = "platforms", version = "1.0.0")
         bazel_dep(name = "rules_cc", version = "0.2.4")
-        bazel_dep(name = "rules_perl", version = "1.1.0")
+        bazel_dep(name = "rules_perl", version = "1.1.2")
 
         http_archive = use_repo_rule(
             "@bazel_tools//tools/build_defs/repo:http.bzl",


### PR DESCRIPTION
Bumps the `rules_perl` dependency from `1.1.0` to `1.1.2` to contain [bazel-contrib/rules_perl#124](https://github.com/bazel-contrib/rules_perl/pull/124).

This updates both:
- the generator module ([`MODULE.bazel`](MODULE.bazel))
- the generated `openssl` `MODULE.bazel` template emitted by [`generate_constants.py`](generate_constants.py)

Requested by @UebelAndre in [bazelbuild/bazel-central-registry#9745](https://github.com/bazelbuild/bazel-central-registry/pull/9745#issuecomment-5023720052) so the change lands in the source of truth and a release can be cut without it getting lost in future updates.